### PR TITLE
datetime tries to coerce values to float/timestamp, since dateutil

### DIFF
--- a/data_schema/convert_value.py
+++ b/data_schema/convert_value.py
@@ -120,9 +120,11 @@ class DatetimeConverter(ValueConverter):
         it assumes it is a unix timestamp. This function also takes care of converting any
         aware datetimes to naive UTC.
         """
-        if self.is_numeric(value):
-            value = datetime.utcfromtimestamp(value)
-        elif self.is_string(value):
+        try:
+            value = datetime.utcfromtimestamp(float(value))
+        except Exception:
+            pass
+        if self.is_string(value):
             value = datetime.strptime(value, format_str) if format_str else parse(value)
 
         # Convert any aware datetime objects to naive utc

--- a/data_schema/tests/convert_value_tests.py
+++ b/data_schema/tests/convert_value_tests.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.test import SimpleTestCase
 
 from data_schema import FieldSchemaType
@@ -54,6 +56,21 @@ class BooleanConverterTest(SimpleTestCase):
         self.assertIsNone(convert_value(FieldSchemaType.BOOLEAN, ''))
         self.assertIsNone(convert_value(FieldSchemaType.BOOLEAN, 'string'))
         self.assertIsNone(convert_value(FieldSchemaType.BOOLEAN, 5))
+
+    def test_convert_datetime(self):
+        """
+        Verifies that datetime field type attempts to coerce to timestamp before
+        attempting to parse the string as a date string
+        """
+        # still
+        self.assertIsInstance(convert_value(FieldSchemaType.DATETIME, 1447251508), datetime)
+        self.assertIsInstance(convert_value(FieldSchemaType.DATETIME, 1447251508.1234), datetime)
+        self.assertIsInstance(convert_value(FieldSchemaType.DATETIME, 1.447251508e9), datetime)
+        self.assertIsInstance(convert_value(FieldSchemaType.DATETIME, '1447251508'), datetime)
+        self.assertIsInstance(convert_value(FieldSchemaType.DATETIME, '1447251508.1234'), datetime)
+        self.assertIsInstance(convert_value(FieldSchemaType.DATETIME, '1.447251508e9'), datetime)
+        # parses date strings
+        self.assertIsInstance(convert_value(FieldSchemaType.DATETIME, '2015-11-09 15:30:00'), datetime)
 
     def test_convert_value_default(self):
         """

--- a/data_schema/tests/tests.py
+++ b/data_schema/tests/tests.py
@@ -8,6 +8,18 @@ from mock import patch
 import pytz
 
 from data_schema.models import DataSchema, FieldSchema, FieldSchemaType, FieldOption
+from data_schema.convert_value import ValueConverter
+
+
+class ValueConverterTest(TestCase):
+    def test_is_numeric(self):
+        converter = ValueConverter(FieldSchemaType.FLOAT, float)
+        self.assertTrue(converter.is_numeric(0))
+        self.assertTrue(converter.is_numeric(100))
+        self.assertTrue(converter.is_numeric(1.34))
+        self.assertTrue(converter.is_numeric(1.34e2))
+        self.assertFalse(converter.is_numeric('foo'))
+        self.assertFalse(converter.is_numeric({'foo': 'bar'}))
 
 
 class FieldSchemaTypeTest(TestCase):


### PR DESCRIPTION
parser is wholly unforgiving when it comes to timestamp strings
